### PR TITLE
パスパラメータ部分の記法を `_foo()` から `_foo` に変更

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -3,5 +3,5 @@ import { mswpida } from '../src';
 
 const mock = mswpida(api, 'https://example.com');
 
-mock.pet._petId().$post();
+mock.pet._petId.$post();
 mock.user.createWithList.$post();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -64,11 +64,11 @@ describe('mswpida', () => {
       })) satisfies AspidaApi;
       const mock = mswpida(api, baseURL);
 
-      expect(mock.items._itemId().$path()).toEqual(`${baseURL}/items/:itemId`);
-      expect(mock.items._itemId().variants.$path()).toEqual(
+      expect(mock.items._itemId.$path()).toEqual(`${baseURL}/items/:itemId`);
+      expect(mock.items._itemId.variants.$path()).toEqual(
         `${baseURL}/items/:itemId/variants`,
       );
-      expect(mock.items._itemId().variants._variantId().$path()).toEqual(
+      expect(mock.items._itemId.variants._variantId.$path()).toEqual(
         `${baseURL}/items/:itemId/variants/:variantId`,
       );
     });
@@ -92,12 +92,9 @@ describe('mswpida', () => {
       },
     })) satisfies AspidaApi;
     const mock = mswpida(api, baseURL);
-    const handler = mock.items
-      ._itemId()
-      .variants._variantId()
-      .$get((req, res, ctx) =>
-        res.once(ctx.status(200), ctx.json({ foo: 'baz' })),
-      );
+    const handler = mock.items._itemId.variants._variantId.$get(
+      (req, res, ctx) => res.once(ctx.status(200), ctx.json({ foo: 'baz' })),
+    );
 
     expect(handler).toBeInstanceOf(RestHandler);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -55,10 +55,7 @@ function createMock<T extends ApiStructure>(apiStructure: T): MockApi<T> {
         const paramName = key.substring(1);
         // @ts-expect-error TODO: 型エラー修正
         const subApiStructure = value(`:${paramName}`) as ApiStructure;
-        return {
-          ...acc,
-          [key]: () => createMock(subApiStructure),
-        };
+        return { ...acc, [key]: createMock(subApiStructure) };
       }
 
       return acc; // ここには来ないはず

--- a/src/type.ts
+++ b/src/type.ts
@@ -61,9 +61,7 @@ type MockEndpoint<T extends ApiStructure> = {
     : never;
 } & { $path: () => string };
 
-type MockPathParamFunction<T extends PathParamFunction> = () => MockApi<
-  ReturnType<T>
->;
+type MockPathParam<T extends PathParamFunction> = MockApi<ReturnType<T>>;
 
 type MockNonEndpointKey<T extends ApiStructure> = Exclude<
   keyof T,
@@ -74,7 +72,7 @@ type MockNonEndpoint<T extends ApiStructure> = {
   [K in MockNonEndpointKey<T>]: T[K] extends ApiStructure
     ? MockApi<T[K]>
     : T[K] extends PathParamFunction
-    ? MockPathParamFunction<T[K]>
+    ? MockPathParam<T[K]>
     : never;
 };
 


### PR DESCRIPTION
aspida の記法 `_foo(value)` に倣って `_foo()` としていたが、`_foo` に変更する。

```ts
// Before
mock.items._itemId().variants._variantId().$get(...);

// After
mock.items._itemId.variants._variantId.$get(...);
```

## 理由

### VS Code 上などで書きやすい

`_foo()` だと `_foo` までは補完されるが、`()` は自分で入力する必要がある。`_foo` にすれば関数呼び出しがなくなるので、`.` の入力と補完候補の選択だけで書いていける。

### Prettier でフォーマットしたときの違和感が少ない

`_foo()` のような関数呼び出しは、単純なプロパティアクセスとは（Prettier 内での）結合の優先度が違うらしく、長くなった場合に `()` の後で改行される。URL 表記との類似性でいうと、あまり改行されない方が読みやすい。

```ts
hogehoge()
  .fugafuga.hogehoge()
  .fugafuga.hogehoge()
  .fugafuga.hogehoge()
  .fugafuga.hogehoge()
  .fugafuga.hogehoge()
  .fugafuga.hogehoge();

hogehoge.fugafuga.hogehoge.fugafuga.hogehoge.fugafuga.hogehoge.fugafuga
  .hogehoge.fugafuga.hogehoge.fugafuga.hogehoge;
```

### 関数である必要がない

aspida ではパスパラメータの値を引数として受け取り、パスを組み立てるようになっている。しかし mswpida の場合は、パスパラメータの名前から一意に決まる（e.g. `:foo`）ため、引数が不要。

```ts
// aspida
api.items._itemId('12345').variants._variantId('abcde').$path();
// => /items/12345/variants/abcde

// mswpida
mock.items._itemId.variants._variantId.$path();
// => /items/:itemId/varants/:variantId
```

一応、「パスパラメータ特定の値のときに限定したモックを作る」というユースケースが考えられなくはない。例えば

```ts
// mswpida
mock.items._itemId('12345').variants._variantId.$path():
// => /items/12345/varants/:variantId
```

のような。ただし、これには mswpida 側で対応するより、モック（resolver）の実装の方でパラメータによって分岐させた方が、柔軟に書ける。

```ts
mock.items._itemId.variants._variantId.$get(
  (req, res, ctx) => {
     if (req.params.itemId === '12345') { ... }
     ...
  };
);
```

よって考慮しないことにする。