### PR TITLE
`req.params` にパスパラメータの型をつける 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -27,7 +27,9 @@ const $METHODS = [
   '$options',
 ] satisfies $LowerHttpMethod[];
 
-function createMock<T extends ApiStructure>(apiStructure: T): MockApi<T> {
+function createMock<TApiStructure extends ApiStructure>(
+  apiStructure: TApiStructure,
+): MockApi<TApiStructure> {
   // @ts-expect-error TODO: 型エラー修正
   return Object.entries(apiStructure).reduce((acc, [key, value]) => {
     if (value instanceof Function) {
@@ -63,13 +65,13 @@ function createMock<T extends ApiStructure>(apiStructure: T): MockApi<T> {
 
     // サブパスのモックを再帰的に作る
     return { ...acc, [key]: createMock(value) };
-  }, {} as MockApi<T>);
+  }, {} as MockApi<TApiStructure>);
 }
 
-export function mswpida<T extends ApiStructure>(
-  api: AspidaApi<T>,
+export function mswpida<TApiStructure extends ApiStructure>(
+  api: AspidaApi<TApiStructure>,
   baseURL?: string,
-): MockApi<T> {
+): MockApi<TApiStructure> {
   const apiStructure = api({
     baseURL,
     // @ts-expect-error 使わないので適当な関数を渡しておく

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,51 +27,56 @@ const $METHODS = [
   '$options',
 ] satisfies $LowerHttpMethod[];
 
-function createMock<TApiStructure extends ApiStructure>(
-  apiStructure: TApiStructure,
-): MockApi<TApiStructure> {
+function createMock<
+  TApiStructure extends ApiStructure,
+  TPathParamName extends string,
+>(apiStructure: TApiStructure): MockApi<TApiStructure, TPathParamName> {
   // @ts-expect-error TODO: 型エラー修正
-  return Object.entries(apiStructure).reduce((acc, [key, value]) => {
-    if (value instanceof Function) {
-      if (key === '$path') {
-        return { ...acc, $path: value };
+  return Object.entries(apiStructure).reduce(
+    // @ts-expect-error TODO: 型エラー修正
+    (acc, [key, value]) => {
+      if (value instanceof Function) {
+        if (key === '$path') {
+          return { ...acc, $path: value };
+        }
+
+        if ($METHODS.includes(key as $LowerHttpMethod)) {
+          // そのメソッドのモック生成関数を返す
+          const method = key.substring(1) as LowerHttpMethod;
+          const path = (apiStructure as Endpoint).$path();
+          return {
+            ...acc,
+            [key]: (resolver: ResponseResolver) => rest[method](path, resolver),
+          };
+        }
+
+        if (METHODS.includes(key as LowerHttpMethod)) {
+          // `$` 無しのメソッドは、モックには用意しない
+          return acc;
+        }
+
+        if (key.startsWith('_')) {
+          // 次の階層がパスパラメータ（e.g. `_foo`）の場合、パスを MSW の形式（`:foo`）に変換した上で、再帰的にモックを作る
+          const paramName = key.substring(1);
+          // @ts-expect-error TODO: 型エラー修正
+          const subApiStructure = value(`:${paramName}`) as ApiStructure;
+          return { ...acc, [key]: createMock(subApiStructure) };
+        }
+
+        return acc; // ここには来ないはず
       }
 
-      if ($METHODS.includes(key as $LowerHttpMethod)) {
-        // そのメソッドのモック生成関数を返す
-        const method = key.substring(1) as LowerHttpMethod;
-        const path = (apiStructure as Endpoint).$path();
-        return {
-          ...acc,
-          [key]: (resolver: ResponseResolver) => rest[method](path, resolver),
-        };
-      }
-
-      if (METHODS.includes(key as LowerHttpMethod)) {
-        // `$` 無しのメソッドは、モックには用意しない
-        return acc;
-      }
-
-      if (key.startsWith('_')) {
-        // 次の階層がパスパラメータ（e.g. `_foo`）の場合、パスを MSW の形式（`:foo`）に変換した上で、再帰的にモックを作る
-        const paramName = key.substring(1);
-        // @ts-expect-error TODO: 型エラー修正
-        const subApiStructure = value(`:${paramName}`) as ApiStructure;
-        return { ...acc, [key]: createMock(subApiStructure) };
-      }
-
-      return acc; // ここには来ないはず
-    }
-
-    // サブパスのモックを再帰的に作る
-    return { ...acc, [key]: createMock(value) };
-  }, {} as MockApi<TApiStructure>);
+      // サブパスのモックを再帰的に作る
+      return { ...acc, [key]: createMock(value) };
+    },
+    {} as MockApi<TApiStructure, TPathParamName>,
+  );
 }
 
 export function mswpida<TApiStructure extends ApiStructure>(
   api: AspidaApi<TApiStructure>,
   baseURL?: string,
-): MockApi<TApiStructure> {
+): MockApi<TApiStructure, never> {
   const apiStructure = api({
     baseURL,
     // @ts-expect-error 使わないので適当な関数を渡しておく

--- a/src/type.ts
+++ b/src/type.ts
@@ -85,7 +85,7 @@ type MockPathParam<
 
 type MockNonEndpointKey<TApiStructure extends ApiStructure> = Exclude<
   keyof TApiStructure,
-  keyof Endpoint
+  keyof Endpoint | number | symbol
 >;
 
 type MockNonEndpoint<

--- a/src/type.ts
+++ b/src/type.ts
@@ -35,46 +35,54 @@ type NonEndpoint = {
 
 export type ApiStructure = Endpoint | NonEndpoint | (Endpoint & NonEndpoint);
 
-export type AspidaApi<T extends ApiStructure = ApiStructure> = ({
+export type AspidaApi<TApiStructure extends ApiStructure = ApiStructure> = ({
   baseURL,
   fetch,
-}: AspidaClient<unknown>) => T;
+}: AspidaClient<unknown>) => TApiStructure;
 
 // mock
 
-type MockMethod<T extends ApiStructure> = Extract<keyof T, $LowerHttpMethod>;
+type MockMethod<TApiStructure extends ApiStructure> = Extract<
+  keyof TApiStructure,
+  $LowerHttpMethod
+>;
 
-type RequestBodyOf<T extends $MethodFetch> = Parameters<T>[0]['body'];
-type ResponseBodyOf<T extends $MethodFetch> = Awaited<ReturnType<T>>;
+type RequestBodyOf<T$MethodFetch extends $MethodFetch> =
+  Parameters<T$MethodFetch>[0]['body'];
+type ResponseBodyOf<T$MethodFetch extends $MethodFetch> = Awaited<
+  ReturnType<T$MethodFetch>
+>;
 
-type HandlerCreator<T extends $MethodFetch> = (
+type HandlerCreator<T$MethodFetch extends $MethodFetch> = (
   resolver: ResponseResolver<
-    RestRequest<RequestBodyOf<T>>, // TODO: パスパラメータの型 RequestParams を定義する
+    RestRequest<RequestBodyOf<T$MethodFetch>>, // TODO: パスパラメータの型 RequestParams を定義する
     RestContext,
-    ResponseBodyOf<T>
+    ResponseBodyOf<T$MethodFetch>
   >,
 ) => RestHandler;
 
-type MockEndpoint<T extends ApiStructure> = {
-  [K in MockMethod<T>]: T[K] extends $MethodFetch
-    ? HandlerCreator<T[K]>
+type MockEndpoint<TApiStructure extends ApiStructure> = {
+  [K in MockMethod<TApiStructure>]: TApiStructure[K] extends $MethodFetch
+    ? HandlerCreator<TApiStructure[K]>
     : never;
 } & { $path: () => string };
 
-type MockPathParam<T extends PathParamFunction> = MockApi<ReturnType<T>>;
+type MockPathParam<TPathParamFunction extends PathParamFunction> = MockApi<
+  ReturnType<TPathParamFunction>
+>;
 
-type MockNonEndpointKey<T extends ApiStructure> = Exclude<
-  keyof T,
+type MockNonEndpointKey<TApiStructure extends ApiStructure> = Exclude<
+  keyof TApiStructure,
   keyof Endpoint
 >;
 
-type MockNonEndpoint<T extends ApiStructure> = {
-  [K in MockNonEndpointKey<T>]: T[K] extends ApiStructure
-    ? MockApi<T[K]>
-    : T[K] extends PathParamFunction
-    ? MockPathParam<T[K]>
+type MockNonEndpoint<TApiStructure extends ApiStructure> = {
+  [K in MockNonEndpointKey<TApiStructure>]: TApiStructure[K] extends ApiStructure
+    ? MockApi<TApiStructure[K]>
+    : TApiStructure[K] extends PathParamFunction
+    ? MockPathParam<TApiStructure[K]>
     : never;
 };
 
-export type MockApi<T extends ApiStructure> = MockNonEndpoint<T> &
-  MockEndpoint<T>;
+export type MockApi<TApiStructure extends ApiStructure> =
+  MockNonEndpoint<TApiStructure> & MockEndpoint<TApiStructure>;

--- a/src/type.ts
+++ b/src/type.ts
@@ -88,6 +88,11 @@ type MockNonEndpointKey<TApiStructure extends ApiStructure> = Exclude<
   keyof Endpoint | number | symbol
 >;
 
+type ExtractPathParamName<TPathParamFunctionName extends string> =
+  TPathParamFunctionName extends `_${infer TPathParamName}`
+    ? TPathParamName
+    : never;
+
 type MockNonEndpoint<
   TApiStructure extends ApiStructure,
   TPathParamName extends string,
@@ -95,7 +100,7 @@ type MockNonEndpoint<
   [K in MockNonEndpointKey<TApiStructure>]: TApiStructure[K] extends ApiStructure
     ? MockApi<TApiStructure[K], TPathParamName>
     : TApiStructure[K] extends PathParamFunction
-    ? MockPathParam<TApiStructure[K], TPathParamName | K> // TODO: _foo から foo に変換
+    ? MockPathParam<TApiStructure[K], TPathParamName | ExtractPathParamName<K>>
     : never;
 };
 


### PR DESCRIPTION
Resolve #15

例：

```ts
mock.items._itemId.variants._variantId.$get(
  (req, res, ctx) => {
    req.params // { itemId: string, variantId: string }
  },
);
```

aspida 的には、パスパラメータの型は `string` もしくは `number` だが、msw では一律 `string` として扱われるので、それに倣って（というか、msw に手を加えずに）一律 `string` にする。