### PR TITLE
export する関数の名前を `mswpida` から `typedRest` に変更

### DIFF
--- a/example/index.ts
+++ b/example/index.ts
@@ -1,12 +1,12 @@
 import api from './generated-api/$api';
-import { mswpida } from '../src';
+import { createTypedRest } from '../src';
 
-const mock = mswpida(api, 'https://example.com');
+const typedRest = createTypedRest(api, 'https://example.com');
 
-mock.pet._petId.$post(async (req, res, ctx) =>
+typedRest.pet._petId.$post(async (req, res, ctx) =>
   res(ctx.status(201), ctx.json(await req.json())),
 );
 
-mock.user.createWithList.$post(async (req, res, ctx) =>
+typedRest.user.createWithList.$post(async (req, res, ctx) =>
   res(ctx.status(201), ctx.json(await req.json())),
 );

--- a/example/index.ts
+++ b/example/index.ts
@@ -1,7 +1,7 @@
 import api from './generated-api/$api';
 import { createTypedRest } from '../src';
 
-const typedRest = createTypedRest(api, 'https://example.com');
+const typedRest = createTypedRest(api, { baseURL: 'https://example.com' });
 
 typedRest.pet._petId.$post(async (req, res, ctx) =>
   res(ctx.status(201), ctx.json(await req.json())),

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,7 +8,7 @@ describe('mswpida', () => {
 
   test('空のAPI', () => {
     const api = (() => ({})) satisfies Api;
-    const typedRest = createTypedRest(api, baseURL);
+    const typedRest = createTypedRest(api, { baseURL });
     expect(typedRest).toEqual({});
   });
 
@@ -33,7 +33,7 @@ describe('mswpida', () => {
           },
         },
       })) satisfies Api;
-      const typedRest = createTypedRest(api, baseURL);
+      const typedRest = createTypedRest(api, { baseURL });
 
       expect(typedRest.$path()).toEqual(`${baseURL}/`);
       expect(typedRest.foo.$path()).toEqual(`${baseURL}/foo`);
@@ -62,7 +62,7 @@ describe('mswpida', () => {
           }),
         },
       })) satisfies Api;
-      const typedRest = createTypedRest(api, baseURL);
+      const typedRest = createTypedRest(api, { baseURL });
 
       expect(typedRest.items._itemId.$path()).toEqual(
         `${baseURL}/items/:itemId`,
@@ -93,7 +93,7 @@ describe('mswpida', () => {
         }),
       },
     })) satisfies Api;
-    const typedRest = createTypedRest(api, baseURL);
+    const typedRest = createTypedRest(api, { baseURL });
     const handler = typedRest.items._itemId.variants._variantId.$get(
       (_req, res, ctx) => res.once(ctx.status(200), ctx.json({ foo: 'baz' })),
     );
@@ -118,7 +118,7 @@ describe('mswpida', () => {
         }),
       },
     })) satisfies Api;
-    const typedRest = createTypedRest(api, baseURL);
+    const typedRest = createTypedRest(api, { baseURL });
     const handler = typedRest.items._itemId.variants._variantId.$get(
       (req, res, ctx) => {
         const itemId = req.params.itemId satisfies string;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { RestHandler } from 'msw';
-import { mswpida } from '.';
+import { createTypedRest } from '.';
 import { AspidaApi } from './type';
 
 describe('mswpida', () => {
@@ -8,8 +8,8 @@ describe('mswpida', () => {
 
   test('空のAPI', () => {
     const api = (() => ({})) satisfies AspidaApi;
-    const mock = mswpida(api, baseURL);
-    expect(mock).toEqual({});
+    const typedRest = createTypedRest(api, baseURL);
+    expect(typedRest).toEqual({});
   });
 
   describe('エンドポイントのパスを $path() で取得できる', () => {
@@ -33,15 +33,15 @@ describe('mswpida', () => {
           },
         },
       })) satisfies AspidaApi;
-      const mock = mswpida(api, baseURL);
+      const typedRest = createTypedRest(api, baseURL);
 
-      expect(mock.$path()).toEqual(`${baseURL}/`);
-      expect(mock.foo.$path()).toEqual(`${baseURL}/foo`);
-      expect(mock.foo.bar.$path()).toEqual(`${baseURL}/foo/bar`);
-      expect(mock.hoge.piyo.$path()).toEqual(`${baseURL}/hoge/piyo`);
+      expect(typedRest.$path()).toEqual(`${baseURL}/`);
+      expect(typedRest.foo.$path()).toEqual(`${baseURL}/foo`);
+      expect(typedRest.foo.bar.$path()).toEqual(`${baseURL}/foo/bar`);
+      expect(typedRest.hoge.piyo.$path()).toEqual(`${baseURL}/hoge/piyo`);
 
       // hoge にはエンドポイントがないので、$path は存在しない
-      expect(mock.hoge).not.toHaveProperty('$path');
+      expect(typedRest.hoge).not.toHaveProperty('$path');
     });
 
     test('パスパラメータを含む場合', () => {
@@ -62,13 +62,15 @@ describe('mswpida', () => {
           }),
         },
       })) satisfies AspidaApi;
-      const mock = mswpida(api, baseURL);
+      const typedRest = createTypedRest(api, baseURL);
 
-      expect(mock.items._itemId.$path()).toEqual(`${baseURL}/items/:itemId`);
-      expect(mock.items._itemId.variants.$path()).toEqual(
+      expect(typedRest.items._itemId.$path()).toEqual(
+        `${baseURL}/items/:itemId`,
+      );
+      expect(typedRest.items._itemId.variants.$path()).toEqual(
         `${baseURL}/items/:itemId/variants`,
       );
-      expect(mock.items._itemId.variants._variantId.$path()).toEqual(
+      expect(typedRest.items._itemId.variants._variantId.$path()).toEqual(
         `${baseURL}/items/:itemId/variants/:variantId`,
       );
     });
@@ -91,8 +93,8 @@ describe('mswpida', () => {
         }),
       },
     })) satisfies AspidaApi;
-    const mock = mswpida(api, baseURL);
-    const handler = mock.items._itemId.variants._variantId.$get(
+    const typedRest = createTypedRest(api, baseURL);
+    const handler = typedRest.items._itemId.variants._variantId.$get(
       (_req, res, ctx) => res.once(ctx.status(200), ctx.json({ foo: 'baz' })),
     );
 
@@ -116,8 +118,8 @@ describe('mswpida', () => {
         }),
       },
     })) satisfies AspidaApi;
-    const mock = mswpida(api, baseURL);
-    const handler = mock.items._itemId.variants._variantId.$get(
+    const typedRest = createTypedRest(api, baseURL);
+    const handler = typedRest.items._itemId.variants._variantId.$get(
       (req, res, ctx) => {
         const itemId = req.params.itemId satisfies string;
         const variantId = req.params.variantId satisfies string;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,13 +1,13 @@
 import { describe, expect, test } from 'vitest';
 import { RestHandler } from 'msw';
 import { createTypedRest } from '.';
-import { AspidaApi } from './type';
+import { Api } from './type';
 
 describe('mswpida', () => {
   const baseURL = 'https://base-url.example.com/v1';
 
   test('空のAPI', () => {
-    const api = (() => ({})) satisfies AspidaApi;
+    const api = (() => ({})) satisfies Api;
     const typedRest = createTypedRest(api, baseURL);
     expect(typedRest).toEqual({});
   });
@@ -32,7 +32,7 @@ describe('mswpida', () => {
             $path: () => `${_baseURL}/hoge/piyo`,
           },
         },
-      })) satisfies AspidaApi;
+      })) satisfies Api;
       const typedRest = createTypedRest(api, baseURL);
 
       expect(typedRest.$path()).toEqual(`${baseURL}/`);
@@ -61,7 +61,7 @@ describe('mswpida', () => {
             },
           }),
         },
-      })) satisfies AspidaApi;
+      })) satisfies Api;
       const typedRest = createTypedRest(api, baseURL);
 
       expect(typedRest.items._itemId.$path()).toEqual(
@@ -92,7 +92,7 @@ describe('mswpida', () => {
           },
         }),
       },
-    })) satisfies AspidaApi;
+    })) satisfies Api;
     const typedRest = createTypedRest(api, baseURL);
     const handler = typedRest.items._itemId.variants._variantId.$get(
       (_req, res, ctx) => res.once(ctx.status(200), ctx.json({ foo: 'baz' })),
@@ -117,7 +117,7 @@ describe('mswpida', () => {
           },
         }),
       },
-    })) satisfies AspidaApi;
+    })) satisfies Api;
     const typedRest = createTypedRest(api, baseURL);
     const handler = typedRest.items._itemId.variants._variantId.$get(
       (req, res, ctx) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,10 +78,10 @@ function createTypedRestFromApiInstance<
 
 export function createTypedRest<TApiInstance extends ApiInstance>(
   api: Api<TApiInstance>,
-  baseURL?: string,
+  options?: { baseURL?: string },
 ): TypedRest<TApiInstance, never> {
   const apiInstance = api({
-    baseURL,
+    baseURL: options?.baseURL,
     // @ts-expect-error 使わないので適当な関数を渡しておく
     fetch: () => 'dummy',
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,6 @@
 import { ResponseResolver, rest } from 'msw';
 import { LowerHttpMethod } from 'aspida';
-import {
-  $LowerHttpMethod,
-  ApiInstance,
-  AspidaApi,
-  Endpoint,
-  MockApi,
-} from './type';
+import { $LowerHttpMethod, ApiInstance, Api, Endpoint, MockApi } from './type';
 
 const METHODS = [
   'get',
@@ -74,7 +68,7 @@ function createMock<
 }
 
 export function createTypedRest<TApiInstance extends ApiInstance>(
-  api: AspidaApi<TApiInstance>,
+  api: Api<TApiInstance>,
   baseURL?: string,
 ): MockApi<TApiInstance, never> {
   const apiInstance = api({

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,7 +73,7 @@ function createMock<
   );
 }
 
-export function mswpida<TApiStructure extends ApiStructure>(
+export function createTypedRest<TApiStructure extends ApiStructure>(
   api: AspidaApi<TApiStructure>,
   baseURL?: string,
 ): MockApi<TApiStructure, never> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,12 @@
 import { ResponseResolver, rest } from 'msw';
 import { LowerHttpMethod } from 'aspida';
-import { $LowerHttpMethod, ApiInstance, Api, Endpoint, MockApi } from './type';
+import {
+  $LowerHttpMethod,
+  ApiInstance,
+  Api,
+  Endpoint,
+  TypedRest,
+} from './type';
 
 const METHODS = [
   'get',
@@ -24,7 +30,7 @@ const $METHODS = [
 function createTypedRestFromApiInstance<
   TApiInstance extends ApiInstance,
   TPathParamName extends string,
->(apiInstance: TApiInstance): MockApi<TApiInstance, TPathParamName> {
+>(apiInstance: TApiInstance): TypedRest<TApiInstance, TPathParamName> {
   // @ts-expect-error TODO: 型エラー修正
   return Object.entries(apiInstance).reduce(
     // @ts-expect-error TODO: 型エラー修正
@@ -66,14 +72,14 @@ function createTypedRestFromApiInstance<
       // サブパスのモックを再帰的に作る
       return { ...acc, [key]: createTypedRestFromApiInstance(value) };
     },
-    {} as MockApi<TApiInstance, TPathParamName>,
+    {} as TypedRest<TApiInstance, TPathParamName>,
   );
 }
 
 export function createTypedRest<TApiInstance extends ApiInstance>(
   api: Api<TApiInstance>,
   baseURL?: string,
-): MockApi<TApiInstance, never> {
+): TypedRest<TApiInstance, never> {
   const apiInstance = api({
     baseURL,
     // @ts-expect-error 使わないので適当な関数を渡しておく

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ const $METHODS = [
   '$options',
 ] satisfies $LowerHttpMethod[];
 
-function createMock<
+function createTypedRestFromApiInstance<
   TApiInstance extends ApiInstance,
   TPathParamName extends string,
 >(apiInstance: TApiInstance): MockApi<TApiInstance, TPathParamName> {
@@ -54,14 +54,17 @@ function createMock<
           const paramName = key.substring(1);
           // @ts-expect-error TODO: 型エラー修正
           const childApiInstance = value(`:${paramName}`) as ApiInstance;
-          return { ...acc, [key]: createMock(childApiInstance) };
+          return {
+            ...acc,
+            [key]: createTypedRestFromApiInstance(childApiInstance),
+          };
         }
 
         return acc; // ここには来ないはず
       }
 
       // サブパスのモックを再帰的に作る
-      return { ...acc, [key]: createMock(value) };
+      return { ...acc, [key]: createTypedRestFromApiInstance(value) };
     },
     {} as MockApi<TApiInstance, TPathParamName>,
   );
@@ -77,5 +80,5 @@ export function createTypedRest<TApiInstance extends ApiInstance>(
     fetch: () => 'dummy',
   });
 
-  return createMock(apiInstance);
+  return createTypedRestFromApiInstance(apiInstance);
 }

--- a/src/type.ts
+++ b/src/type.ts
@@ -33,9 +33,11 @@ type NonEndpoint = {
   [K in string]: ApiInstance | PathParamFunction;
 };
 
+/** aspida で生成した `api()` 関数の戻り値の型 */
 export type ApiInstance = Endpoint | NonEndpoint | (Endpoint & NonEndpoint);
 
-export type AspidaApi<TApiInstance extends ApiInstance = ApiInstance> = ({
+/** aspida で生成した `api()` 関数の型 */
+export type Api<TApiInstance extends ApiInstance = ApiInstance> = ({
   baseURL,
   fetch,
 }: AspidaClient<unknown>) => TApiInstance;

--- a/src/type.ts
+++ b/src/type.ts
@@ -84,11 +84,6 @@ type EndpointTypedRest<
     : never;
 } & { $path: () => string };
 
-type PathParamTypedRest<
-  TPathParamFunction extends PathParamFunction,
-  TPathParamName extends string,
-> = TypedRest<ReturnType<TPathParamFunction>, TPathParamName>;
-
 type NonEndpointTypedRestKey<TApiInstance extends ApiInstance> = Exclude<
   keyof TApiInstance,
   keyof Endpoint | number | symbol
@@ -106,8 +101,8 @@ type NonEndpointTypedRest<
   [K in NonEndpointTypedRestKey<TApiInstance>]: TApiInstance[K] extends ApiInstance
     ? TypedRest<TApiInstance[K], TPathParamName>
     : TApiInstance[K] extends PathParamFunction
-    ? PathParamTypedRest<
-        TApiInstance[K],
+    ? TypedRest<
+        ReturnType<TApiInstance[K]>,
         TPathParamName | ExtractPathParamName<K>
       >
     : never;

--- a/src/type.ts
+++ b/src/type.ts
@@ -26,24 +26,24 @@ export type Endpoint = Partial<Record<LowerHttpMethod, MethodFetch>> &
   };
 
 type PathParamFunction =
-  | ((param: string) => ApiStructure)
-  | ((param: number) => ApiStructure);
+  | ((param: string) => ApiInstance)
+  | ((param: number) => ApiInstance);
 
 type NonEndpoint = {
-  [K in string]: ApiStructure | PathParamFunction;
+  [K in string]: ApiInstance | PathParamFunction;
 };
 
-export type ApiStructure = Endpoint | NonEndpoint | (Endpoint & NonEndpoint);
+export type ApiInstance = Endpoint | NonEndpoint | (Endpoint & NonEndpoint);
 
-export type AspidaApi<TApiStructure extends ApiStructure = ApiStructure> = ({
+export type AspidaApi<TApiInstance extends ApiInstance = ApiInstance> = ({
   baseURL,
   fetch,
-}: AspidaClient<unknown>) => TApiStructure;
+}: AspidaClient<unknown>) => TApiInstance;
 
 // mock
 
-type MockMethod<TApiStructure extends ApiStructure> = Extract<
-  keyof TApiStructure,
+type MockMethod<TApiInstance extends ApiInstance> = Extract<
+  keyof TApiInstance,
   $LowerHttpMethod
 >;
 
@@ -70,11 +70,11 @@ type HandlerCreator<
 ) => RestHandler;
 
 type MockEndpoint<
-  TApiStructure extends ApiStructure,
+  TApiInstance extends ApiInstance,
   TPathParamName extends string,
 > = {
-  [K in MockMethod<TApiStructure>]: TApiStructure[K] extends $MethodFetch
-    ? HandlerCreator<TApiStructure[K], TPathParamName>
+  [K in MockMethod<TApiInstance>]: TApiInstance[K] extends $MethodFetch
+    ? HandlerCreator<TApiInstance[K], TPathParamName>
     : never;
 } & { $path: () => string };
 
@@ -83,8 +83,8 @@ type MockPathParam<
   TPathParamName extends string,
 > = MockApi<ReturnType<TPathParamFunction>, TPathParamName>;
 
-type MockNonEndpointKey<TApiStructure extends ApiStructure> = Exclude<
-  keyof TApiStructure,
+type MockNonEndpointKey<TApiInstance extends ApiInstance> = Exclude<
+  keyof TApiInstance,
   keyof Endpoint | number | symbol
 >;
 
@@ -94,18 +94,18 @@ type ExtractPathParamName<TPathParamFunctionName extends string> =
     : never;
 
 type MockNonEndpoint<
-  TApiStructure extends ApiStructure,
+  TApiInstance extends ApiInstance,
   TPathParamName extends string,
 > = {
-  [K in MockNonEndpointKey<TApiStructure>]: TApiStructure[K] extends ApiStructure
-    ? MockApi<TApiStructure[K], TPathParamName>
-    : TApiStructure[K] extends PathParamFunction
-    ? MockPathParam<TApiStructure[K], TPathParamName | ExtractPathParamName<K>>
+  [K in MockNonEndpointKey<TApiInstance>]: TApiInstance[K] extends ApiInstance
+    ? MockApi<TApiInstance[K], TPathParamName>
+    : TApiInstance[K] extends PathParamFunction
+    ? MockPathParam<TApiInstance[K], TPathParamName | ExtractPathParamName<K>>
     : never;
 };
 
 export type MockApi<
-  TApiStructure extends ApiStructure,
+  TApiInstance extends ApiInstance,
   TPathParamName extends string,
-> = MockNonEndpoint<TApiStructure, TPathParamName> &
-  MockEndpoint<TApiStructure, TPathParamName>;
+> = MockNonEndpoint<TApiInstance, TPathParamName> &
+  MockEndpoint<TApiInstance, TPathParamName>;

--- a/src/type.ts
+++ b/src/type.ts
@@ -13,7 +13,9 @@ import type {
 
 export type $LowerHttpMethod = `$${LowerHttpMethod}`;
 
-// api
+//
+// aspida が生成する API クライアントの型
+//
 
 type MethodFetch = (
   option: Required<AspidaParams>,
@@ -42,9 +44,11 @@ export type Api<TApiInstance extends ApiInstance = ApiInstance> = ({
   fetch,
 }: AspidaClient<unknown>) => TApiInstance;
 
-// mock
+//
+// mswpida が生成する typedRest の型
+//
 
-type MockMethod<TApiInstance extends ApiInstance> = Extract<
+type TypedRestMethod<TApiInstance extends ApiInstance> = Extract<
   keyof TApiInstance,
   $LowerHttpMethod
 >;
@@ -71,21 +75,21 @@ type HandlerCreator<
   >,
 ) => RestHandler;
 
-type MockEndpoint<
+type EndpointTypedRest<
   TApiInstance extends ApiInstance,
   TPathParamName extends string,
 > = {
-  [K in MockMethod<TApiInstance>]: TApiInstance[K] extends $MethodFetch
+  [K in TypedRestMethod<TApiInstance>]: TApiInstance[K] extends $MethodFetch
     ? HandlerCreator<TApiInstance[K], TPathParamName>
     : never;
 } & { $path: () => string };
 
-type MockPathParam<
+type PathParamTypedRest<
   TPathParamFunction extends PathParamFunction,
   TPathParamName extends string,
-> = MockApi<ReturnType<TPathParamFunction>, TPathParamName>;
+> = TypedRest<ReturnType<TPathParamFunction>, TPathParamName>;
 
-type MockNonEndpointKey<TApiInstance extends ApiInstance> = Exclude<
+type NonEndpointTypedRestKey<TApiInstance extends ApiInstance> = Exclude<
   keyof TApiInstance,
   keyof Endpoint | number | symbol
 >;
@@ -95,19 +99,22 @@ type ExtractPathParamName<TPathParamFunctionName extends string> =
     ? TPathParamName
     : never;
 
-type MockNonEndpoint<
+type NonEndpointTypedRest<
   TApiInstance extends ApiInstance,
   TPathParamName extends string,
 > = {
-  [K in MockNonEndpointKey<TApiInstance>]: TApiInstance[K] extends ApiInstance
-    ? MockApi<TApiInstance[K], TPathParamName>
+  [K in NonEndpointTypedRestKey<TApiInstance>]: TApiInstance[K] extends ApiInstance
+    ? TypedRest<TApiInstance[K], TPathParamName>
     : TApiInstance[K] extends PathParamFunction
-    ? MockPathParam<TApiInstance[K], TPathParamName | ExtractPathParamName<K>>
+    ? PathParamTypedRest<
+        TApiInstance[K],
+        TPathParamName | ExtractPathParamName<K>
+      >
     : never;
 };
 
-export type MockApi<
+export type TypedRest<
   TApiInstance extends ApiInstance,
   TPathParamName extends string,
-> = MockNonEndpoint<TApiInstance, TPathParamName> &
-  MockEndpoint<TApiInstance, TPathParamName>;
+> = NonEndpointTypedRest<TApiInstance, TPathParamName> &
+  EndpointTypedRest<TApiInstance, TPathParamName>;


### PR DESCRIPTION
また、それに合わせて内部の型名や関数名も変更。