### PR TITLE
`release` script の typo を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lint:prettier": "prettier --check .",
     "lint:tsc": "tsc --noEmit",
     "test": "vitest",
-    "release": "pnpm build && changesets publish"
+    "release": "pnpm build && changeset publish"
   },
   "devDependencies": {
     "@aspida/fetch": "^1.14.0",


### PR DESCRIPTION
https://github.com/mashabow/mswpida/pull/29 をマージしてリリースが走るかと思いきや、typo でコケていた 😇

https://github.com/mashabow/mswpida/actions/runs/6787012416/job/18448855868